### PR TITLE
Fix build error when only VS 2013 is installed. 

### DIFF
--- a/Build/Wintellect.TFSBuildNumber.targets
+++ b/Build/Wintellect.TFSBuildNumber.targets
@@ -80,8 +80,8 @@
 
   <PropertyGroup>
     <!-- Figure out where the TFS build tasks are. -->
-    <TeamBuildRefPath Condition="'$(TeamBuildRefPath)' == ''">$(VS110COMNTOOLS)..\IDE\PrivateAssemblies\</TeamBuildRefPath>
-    <TeamBuildRefPath Condition="'$(TeamBuildRefPath)' == ''">$(VS120COMNTOOLS)..\IDE\PrivateAssemblies\</TeamBuildRefPath>
+    <TeamBuildRefPath Condition="'$(TeamBuildRefPath)' == '' and '$(VS120COMNTOOLS' != ''">$(VS120COMNTOOLS)..\IDE\PrivateAssemblies\</TeamBuildRefPath>
+    <TeamBuildRefPath Condition="'$(TeamBuildRefPath)' == '' and '$(VS110COMNTOOLS' != ''">$(VS110COMNTOOLS)..\IDE\PrivateAssemblies\</TeamBuildRefPath>
   </PropertyGroup>
 
   <!-- Set appropriate defaults for all version files. -->


### PR DESCRIPTION
Fix build error when only VS 2013 is installed, and configure to use the newest version installed.
