### PR TITLE
TFSBuildNumber can be predefined

### DIFF
--- a/Build/Wintellect.TFSBuildNumber.targets
+++ b/Build/Wintellect.TFSBuildNumber.targets
@@ -80,8 +80,8 @@
 
   <PropertyGroup>
     <!-- Figure out where the TFS build tasks are. -->
-    <TeamBuildRefPath Condition="'$(TeamBuildRefPath)' == '' and '$(VS120COMNTOOLS' != ''">$(VS120COMNTOOLS)..\IDE\PrivateAssemblies\</TeamBuildRefPath>
-    <TeamBuildRefPath Condition="'$(TeamBuildRefPath)' == '' and '$(VS110COMNTOOLS' != ''">$(VS110COMNTOOLS)..\IDE\PrivateAssemblies\</TeamBuildRefPath>
+    <TeamBuildRefPath Condition="'$(TeamBuildRefPath)' == '' and '$(VS120COMNTOOLS)' != ''">$(VS120COMNTOOLS)..\IDE\PrivateAssemblies\</TeamBuildRefPath>
+    <TeamBuildRefPath Condition="'$(TeamBuildRefPath)' == '' and '$(VS110COMNTOOLS)' != ''">$(VS110COMNTOOLS)..\IDE\PrivateAssemblies\</TeamBuildRefPath>
   </PropertyGroup>
 
   <!-- Set appropriate defaults for all version files. -->


### PR DESCRIPTION
Allow TFSBuildNumber and other properties to be predefined and not ovewritten. Fixes bug #2
