### PR TITLE
USERDOMAIN check change for TFS Hosted Build

### DIFF
--- a/Build/Wintellect.TFSBuildNumber.targets
+++ b/Build/Wintellect.TFSBuildNumber.targets
@@ -74,7 +74,7 @@
     <!-- For a TFS Hosted build, I'll look to see if the domain and user 
          account have the special domain and user account. Obviously, if 
          Microsoft changes the accounts, this will break. -->
-    <WintellectBuildType Condition=" '$(BuildLabel)' != '' and '$(USERNAME)' == 'buildguest' and '$(USERDOMAIN.StartsWith(`BUILD-`))' == 'true' ">TFSHOSTEDBUILD</WintellectBuildType>
+    <WintellectBuildType Condition=" '$(BuildLabel)' != '' and '$(USERNAME)' == 'buildguest' and '$(USERDOMAIN.StartsWith(`BUILD`))' == 'true' ">TFSHOSTEDBUILD</WintellectBuildType>
     <!-- If it's not TFS Hosted, try an on premises build machine. -->
     <WintellectBuildType Condition=" '$(BuildUri)'!='' and '$(TeamFoundationServerUrl)'!='' and '$(WintellectBuildType)' == '' ">TFSONPREMBUILD</WintellectBuildType>
     <!-- Default to a developer build. -->


### PR DESCRIPTION
Sometime after November 5, 2015, Microsoft changed their USERDOMAIN and
COMPUTERNAME Properties for my TFS Hosted Build. I assume others will run into this issue at some point. As of 1/4/2016, my TFS hosted build has the following Properties:

```
COMPUTERNAME = BUILD2-0017
USERDOMAIN = BUILD2-0017
```

This update will accommodate these new property names. With the existing
code - with the new computer name - it thought the build was
TFSONPREMBUILD, and threw the Exception:

```
Microsoft.TeamFoundation.TeamFoundationServerUnauthorizedException:
TF30063: You are not authorized to access
https://{YourCollectionName}.visualstudio.com/DefaultCollection.
```

It would be helpful to throw a different exception, as this behavior made it a bit more challenging to find the issue.
